### PR TITLE
add CNAME file for domain hosting

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.venturebuild.co


### PR DESCRIPTION
the CNAME file is used to associate the custom domain (in this case, www.venturebuild.co) with the GitHub Pages site (african-impact-initiative.github.io). This file tells GitHup Pages to serve the site from the custom domain instead of the default github.