### PR TITLE
add base path to allow asset URLs are correctly resolved

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    base: '/',
     plugins: [react()],
 })


### PR DESCRIPTION
The base property in Vite's configuration specifies the base public path for the project when served in development or production. It affects how URLs for assets (like scripts, styles, images) are resolved. Configuring this properly should allow main.tsx be properly rendered by index.html when loading venturebuild.co